### PR TITLE
Add `register-form-address-not-required` code snippet

### DIFF
--- a/lifterlms/register-form-address-not-required.php
+++ b/lifterlms/register-form-address-not-required.php
@@ -1,0 +1,25 @@
+<?php // <- Don't copy this line.
+
+/**
+ * Make address and phone fields not required on free plan checkout.
+ *
+ * @param array $settings The field settings.
+ *
+ * @return array
+ */
+add_filter( 'llms_field_settings', function ( array $settings ): array {
+	$id = $settings['id'] ?? '';
+
+	if ( str_contains( $id, 'billing' ) || str_contains( $id, 'phone' ) ) {
+
+		$plan    = (int) llms_filter_input( INPUT_GET, 'plan', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		$is_free = ( llms_get_post( $plan )->get( 'is_free' ) ?? null ) === 'yes';
+
+		if ( $is_free ) {
+			$settings['required'] = false;
+		}
+	}
+
+	return $settings;
+}, 10 );
+

--- a/lifterlms/register-form-address-not-required.php
+++ b/lifterlms/register-form-address-not-required.php
@@ -3,6 +3,8 @@
 /**
  * Make address and phone fields not required on free plan checkout.
  *
+ * @since 08/17/2023
+ *
  * @param array $settings The field settings.
  *
  * @return array


### PR DESCRIPTION
## Description

Adds snippet which allows Address and Phone fields to be optional on registration for free plans.

See #HS-224600

## How has this been tested?

Manually

## Types of changes

New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] This PR requires and contains at least one changelog file.
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding & Documentation Standards.

