### PR TITLE
Exclude posts given their IDs to users with specific roles.

### DIFF
--- a/lifterlms/courses-lessons/exclude-posts-from-user-roles.php
+++ b/lifterlms/courses-lessons/exclude-posts-from-user-roles.php
@@ -1,8 +1,10 @@
+<?php // Don't copy this line!
+
 /**
  * Exclude posts (given their IDs) from being seen by users given a list of roles.
- * 
+ *
  * Learn more at: https://lifterlms.com/link-to-content-if-available-or-remove-this-line/
- * 
+ *
  * You can add this recipe to your site by creating a custom plugin
  * or using the Code Snippets plugin available for free in the WordPress repository.
  * Read this companion documentation for step-by-step directions on either method.
@@ -11,40 +13,40 @@
 
 function exclude_posts_for_roles($query) {
     // Do not exclude when the user is the WordPress administrator
-    if (is_admin()) {
+    if ( is_admin() ) {
         return;
     }
 
     // Replace the array with your actual roles you want
     $roles_to_exclude = array(
-		'student',
-		'editor'
-	);
+        'student',
+        'editor',
+    );
 
     // Replace the array with your actual post IDs to exclude
     $posts_to_exclude = array(
-		20,
-		22
-	);
+        20,
+        22,
+    );
 
     // If the user is not logged in, we cannot check their role
     // So exclude the posts from non-logged in visitors
-    if (!is_user_logged_in()) {
-       $query->set('post__not_in', $posts_to_exclude);
-       return;
-	}
+    if ( !is_user_logged_in() ) {
+        $query->set('post__not_in', $posts_to_exclude);
+        return;
+    }
 
     // Check if the logged-in user has any of the specified roles
     $user_has_excluded_role = false;
-    foreach ($roles_to_exclude as $role) {
-        if (current_user_can($role)) {
-            $user_has_excluded_role = true;
-            break;
-        }
+    $user = wp_get_current_user();
+    $user_roles = ( array ) $user->roles;
+    $intersect = array_intersect($user_roles, $roles_to_exclude);
+    if ( ! empty($intersect) ) {
+        $user_has_excluded_role = true;
     }
 
     // If the user has any of the specified roles, exclude the specific posts
-    if ($user_has_excluded_role) {
+    if ( $user_has_excluded_role ) {
         $query->set('post__not_in', $posts_to_exclude);
     }
 }

--- a/lifterlms/courses-lessons/exclude-posts-from-user-roles.php
+++ b/lifterlms/courses-lessons/exclude-posts-from-user-roles.php
@@ -10,24 +10,31 @@
  */
 
 function exclude_posts_for_roles($query) {
-    // Check if it is the main query and the user is logged in
-    if (is_admin() || !$query->is_main_query() || !is_user_logged_in()) {
+    // Do not exclude when the user is the WordPress administrator
+    if (is_admin()) {
         return;
     }
 
     // Replace the array with your actual roles you want
     $roles_to_exclude = array(
-		    'student',
-		    'editor'
-	  );
+		'student',
+		'editor'
+	);
 
     // Replace the array with your actual post IDs to exclude
     $posts_to_exclude = array(
-		    98,
-		    109
-	  );
+		20,
+		22
+	);
 
-    // Check if the user has any of the specified roles
+    // If the user is not logged in, we cannot check their role
+    // So exclude the posts from non-logged in visitors
+    if (!is_user_logged_in()) {
+       $query->set('post__not_in', $posts_to_exclude);
+       return;
+	}
+
+    // Check if the logged-in user has any of the specified roles
     $user_has_excluded_role = false;
     foreach ($roles_to_exclude as $role) {
         if (current_user_can($role)) {

--- a/lifterlms/courses-lessons/exclude-posts-from-user-roles.php
+++ b/lifterlms/courses-lessons/exclude-posts-from-user-roles.php
@@ -1,0 +1,45 @@
+/**
+ * Exclude posts (given their IDs) from being seen by users given a list of roles.
+ * 
+ * Learn more at: https://lifterlms.com/link-to-content-if-available-or-remove-this-line/
+ * 
+ * You can add this recipe to your site by creating a custom plugin
+ * or using the Code Snippets plugin available for free in the WordPress repository.
+ * Read this companion documentation for step-by-step directions on either method.
+ * https://lifterlms.com/docs/adding-custom-code/
+ */
+
+function exclude_posts_for_roles($query) {
+    // Check if it is the main query and the user is logged in
+    if (is_admin() || !$query->is_main_query() || !is_user_logged_in()) {
+        return;
+    }
+
+    // Replace the array with your actual roles you want
+    $roles_to_exclude = array(
+		    'student',
+		    'editor'
+	  );
+
+    // Replace the array with your actual post IDs to exclude
+    $posts_to_exclude = array(
+		    98,
+		    109
+	  );
+
+    // Check if the user has any of the specified roles
+    $user_has_excluded_role = false;
+    foreach ($roles_to_exclude as $role) {
+        if (current_user_can($role)) {
+            $user_has_excluded_role = true;
+            break;
+        }
+    }
+
+    // If the user has any of the specified roles, exclude the specific posts
+    if ($user_has_excluded_role) {
+        $query->set('post__not_in', $posts_to_exclude);
+    }
+}
+
+add_action('pre_get_posts', 'exclude_posts_for_roles');


### PR DESCRIPTION
<!--
Contributors:
Prior to opening a pull request, please review our contributing guidelines at https://github.com/gocodebox/lifterlms/blob/trunk/.github/CONTRIBUTING.md
-->

## Description
Added code to exclude posts given their IDs to users with specific roles.

## How has this been tested?
1. Tested locally on a fresh install of WordPress and LifterLMS, for both logged in and logged out users.
2. Tested that these changes are also affecting the blog post loops.
