### PR TITLE
Exclude posts given their IDs from being seen by users with given WordPress roles.

### DIFF
--- a/lifterlms-groups/automatically-create-group-with-group-admin-when-purchased-via-woocommerce.php
+++ b/lifterlms-groups/automatically-create-group-with-group-admin-when-purchased-via-woocommerce.php
@@ -1,0 +1,61 @@
+<?php // Do not copy this line!
+/**
+ * Create a LifterLMS Group for every WooCommerce order. Set the number of seats
+ * to be equal to the "quantity" of items bought in WooCommerce.
+ *
+ * You can add this recipe to your site by creating a custom plugin
+ * or using the Code Snippets plugin available for free in the WordPress repository.
+ * Read this companion documentation for step-by-step directions on either method.
+ * https://lifterlms.com/docs/adding-custom-code/
+ *
+ * @param int $order_id The WooCommerce order ID.
+ *
+ * @return void
+ */
+function create_llms_group_with_admin($order_id)
+{
+    if (class_exists('LLMS_Group') && class_exists('LLMS_Groups_Enrollment') ) {
+        // Get integration.
+        $integration = llms_groups()->get_integration();
+        $name        = $integration->get_option('post_name_singular');
+        $visibility  = $integration->get_option('visibility')
+
+        // Setup arguments.
+        $args = wp_parse_args(
+            $args,
+            array(
+                'post_status' => 'publish',
+                'post_title'  => sprintf(__('New %s', 'lifterlms-groups'), $name),
+                'meta_input'  => array(
+                    '_llms_visibility' => $visibility,
+                ),
+            )
+        );
+
+        // Create the group.
+        $group = new LLMS_Group('new', $args);
+
+        // Assign group administrator.
+        $order = wc_get_order($order_id);
+        LLMS_Groups_Enrollment::add(
+            $order->get_user_id(),
+            $group->get('id'),
+            'woocommerce_order',
+            'admin'
+        );
+
+        $order_data = $order->get_data();
+
+        // Assign the number of seats in the group.
+        // You're developer can modify this logic to be as custom as you want.
+        foreach ($order->get_items() as $item_key => $item ) {
+            $product = wc_get_product($item['product_id']);
+            $quantity = $item->get_quantity();
+            $group->set('seats', $quantity);
+        }
+    }
+}
+
+add_action('woocommerce_order_status_completed', 'create_llms_group_with_admin');
+add_action('woocommerce_order_status_processing', 'create_llms_group_with_admin');
+

--- a/lifterlms/courses-lessons/exclude-posts-from-user-roles.php
+++ b/lifterlms/courses-lessons/exclude-posts-from-user-roles.php
@@ -1,5 +1,4 @@
-<?php
-
+<?php // Do not copy this line!
 /**
  * Exclude posts (given their IDs) from being seen by users given a list of roles.
  *
@@ -10,7 +9,7 @@
  * Read this companion documentation for step-by-step directions on either method.
  * https://lifterlms.com/docs/adding-custom-code/
  *
- * @param WP_Query @query The WP_Query to modify.
+ * @param WP_Query $query The WP_Query to modify.
  */
 function exclude_posts_for_roles( $query ) {
 	// Do not exclude when the user is the WordPress administrator.

--- a/lifterlms/courses-lessons/exclude-posts-from-user-roles.php
+++ b/lifterlms/courses-lessons/exclude-posts-from-user-roles.php
@@ -1,8 +1,10 @@
+<?php // Don't copy this line!
+
 /**
  * Exclude posts (given their IDs) from being seen by users given a list of roles.
- * 
+ *
  * Learn more at: https://lifterlms.com/link-to-content-if-available-or-remove-this-line/
- * 
+ *
  * You can add this recipe to your site by creating a custom plugin
  * or using the Code Snippets plugin available for free in the WordPress repository.
  * Read this companion documentation for step-by-step directions on either method.
@@ -11,40 +13,40 @@
 
 function exclude_posts_for_roles($query) {
     // Do not exclude when the user is the WordPress administrator
-    if (is_admin()) {
+    if ( is_admin() ) {
         return;
     }
 
     // Replace the array with your actual roles you want
     $roles_to_exclude = array(
-		'student',
-		'editor'
-	);
+        'student',
+        'editor',
+    );
 
     // Replace the array with your actual post IDs to exclude
     $posts_to_exclude = array(
-		20,
-		22
-	);
+        20,
+        22,
+    );
 
     // If the user is not logged in, we cannot check their role
     // So exclude the posts from non-logged in visitors
-    if (!is_user_logged_in()) {
-       $query->set('post__not_in', $posts_to_exclude);
-       return;
-	}
+    if ( !is_user_logged_in() ) {
+        $query->set('post__not_in', $posts_to_exclude);
+        return;
+    }
 
     // Check if the logged-in user has any of the specified roles
     $user_has_excluded_role = false;
-    foreach ($roles_to_exclude as $role) {
-        if (current_user_can($role)) {
-            $user_has_excluded_role = true;
-            break;
-        }
+    $user = wp_get_current_user();
+    $user_roles = ( array ) $user->roles;
+    $intersect = array_intersect($user_roles, $roles_to_exclude);
+    if ( ! empty($intersect) ) {
+        $user_has_excluded_role = true;
     }
 
     // If the user has any of the specified roles, exclude the specific posts
-    if ($user_has_excluded_role) {
+    if ( $user_has_excluded_role ) {
         $query->set('post__not_in', $posts_to_exclude);
     }
 }

--- a/lifterlms/courses-lessons/exclude-posts-from-user-roles.php
+++ b/lifterlms/courses-lessons/exclude-posts-from-user-roles.php
@@ -10,24 +10,31 @@
  */
 
 function exclude_posts_for_roles($query) {
-    // Check if it is the main query and the user is logged in
-    if (is_admin() || !$query->is_main_query() || !is_user_logged_in()) {
+    // Do not exclude when the user is the WordPress administrator
+    if (is_admin()) {
         return;
     }
 
     // Replace the array with your actual roles you want
     $roles_to_exclude = array(
-		    'student',
-		    'editor'
-	  );
+		'student',
+		'editor'
+	);
 
     // Replace the array with your actual post IDs to exclude
     $posts_to_exclude = array(
-		    98,
-		    109
-	  );
+		20,
+		22
+	);
 
-    // Check if the user has any of the specified roles
+    // If the user is not logged in, we cannot check their role
+    // So exclude the posts from non-logged in visitors
+    if (!is_user_logged_in()) {
+       $query->set('post__not_in', $posts_to_exclude);
+       return;
+	}
+
+    // Check if the logged-in user has any of the specified roles
     $user_has_excluded_role = false;
     foreach ($roles_to_exclude as $role) {
         if (current_user_can($role)) {

--- a/lifterlms/courses-lessons/exclude-posts-from-user-roles.php
+++ b/lifterlms/courses-lessons/exclude-posts-from-user-roles.php
@@ -1,0 +1,45 @@
+/**
+ * Exclude posts (given their IDs) from being seen by users given a list of roles.
+ * 
+ * Learn more at: https://lifterlms.com/link-to-content-if-available-or-remove-this-line/
+ * 
+ * You can add this recipe to your site by creating a custom plugin
+ * or using the Code Snippets plugin available for free in the WordPress repository.
+ * Read this companion documentation for step-by-step directions on either method.
+ * https://lifterlms.com/docs/adding-custom-code/
+ */
+
+function exclude_posts_for_roles($query) {
+    // Check if it is the main query and the user is logged in
+    if (is_admin() || !$query->is_main_query() || !is_user_logged_in()) {
+        return;
+    }
+
+    // Replace the array with your actual roles you want
+    $roles_to_exclude = array(
+		    'student',
+		    'editor'
+	  );
+
+    // Replace the array with your actual post IDs to exclude
+    $posts_to_exclude = array(
+		    98,
+		    109
+	  );
+
+    // Check if the user has any of the specified roles
+    $user_has_excluded_role = false;
+    foreach ($roles_to_exclude as $role) {
+        if (current_user_can($role)) {
+            $user_has_excluded_role = true;
+            break;
+        }
+    }
+
+    // If the user has any of the specified roles, exclude the specific posts
+    if ($user_has_excluded_role) {
+        $query->set('post__not_in', $posts_to_exclude);
+    }
+}
+
+add_action('pre_get_posts', 'exclude_posts_for_roles');

--- a/lifterlms/courses-lessons/exclude-posts-from-user-roles.php
+++ b/lifterlms/courses-lessons/exclude-posts-from-user-roles.php
@@ -1,4 +1,4 @@
-<?php // Don't copy this line!
+<?php
 
 /**
  * Exclude posts (given their IDs) from being seen by users given a list of roles.
@@ -9,46 +9,47 @@
  * or using the Code Snippets plugin available for free in the WordPress repository.
  * Read this companion documentation for step-by-step directions on either method.
  * https://lifterlms.com/docs/adding-custom-code/
+ *
+ * @param WP_Query @query The WP_Query to modify.
  */
+function exclude_posts_for_roles( $query ) {
+	// Do not exclude when the user is the WordPress administrator.
+	if ( is_admin() ) {
+		return;
+	}
 
-function exclude_posts_for_roles($query) {
-    // Do not exclude when the user is the WordPress administrator
-    if ( is_admin() ) {
-        return;
-    }
+	// Replace the array with your actual roles you want.
+	$roles_to_exclude = array(
+		'student',
+		'editor',
+	);
 
-    // Replace the array with your actual roles you want
-    $roles_to_exclude = array(
-        'student',
-        'editor',
-    );
+	// Replace the array with your actual post IDs to exclude.
+	$posts_to_exclude = array(
+		20,
+		22,
+	);
 
-    // Replace the array with your actual post IDs to exclude
-    $posts_to_exclude = array(
-        20,
-        22,
-    );
+	// If the user is not logged in, we cannot check their role.
+	// So exclude the posts from non-logged in visitors.
+	if ( ! is_user_logged_in() ) {
+		$query->set( 'post__not_in', $posts_to_exclude );
+		return;
+	}
 
-    // If the user is not logged in, we cannot check their role
-    // So exclude the posts from non-logged in visitors
-    if ( !is_user_logged_in() ) {
-        $query->set('post__not_in', $posts_to_exclude);
-        return;
-    }
+	// Check if the logged-in user has any of the specified roles.
+	$user_has_excluded_role = false;
+	$user                   = wp_get_current_user();
+	$user_roles             = (array) $user->roles;
+	$intersect              = array_intersect( $user_roles, $roles_to_exclude );
+	if ( ! empty( $intersect ) ) {
+		$user_has_excluded_role = true;
+	}
 
-    // Check if the logged-in user has any of the specified roles
-    $user_has_excluded_role = false;
-    $user = wp_get_current_user();
-    $user_roles = ( array ) $user->roles;
-    $intersect = array_intersect($user_roles, $roles_to_exclude);
-    if ( ! empty($intersect) ) {
-        $user_has_excluded_role = true;
-    }
-
-    // If the user has any of the specified roles, exclude the specific posts
-    if ( $user_has_excluded_role ) {
-        $query->set('post__not_in', $posts_to_exclude);
-    }
+	// If the user has any of the specified roles, exclude the specific posts.
+	if ( $user_has_excluded_role ) {
+		$query->set( 'post__not_in', $posts_to_exclude );
+	}
 }
 
-add_action('pre_get_posts', 'exclude_posts_for_roles');
+add_action( 'pre_get_posts', 'exclude_posts_for_roles' );


### PR DESCRIPTION
<!--
Contributors:
Prior to opening a pull request, please review our contributing guidelines at https://github.com/gocodebox/lifterlms/blob/trunk/.github/CONTRIBUTING.md
-->

## Description
Exclude posts given their IDs from being seen by users with given WordPress roles.

## How has this been tested?
Locally using the student roles and some posts in `WordPress Dashboard > Posts`.

## Types of changes
Code snippet.

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [x] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

